### PR TITLE
Don't transform non-JS files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ module.exports = function(tree) {
     throw new Error('`fastboot-transform` requires broccoli tree as input.');
   }
 
-  return map(tree, (content) => `if (typeof FastBoot === 'undefined') {\n${content}\n}`);
+  return map(tree, '**/*.js', (content) => `if (typeof FastBoot === 'undefined') {\n${content}\n}`);
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -25,15 +25,17 @@ describe('fastboot-transform', function() {
     yield output.dispose();
   }));
 
-  it('should transform', co.wrap(function* () {
+  it('should transform JS files', co.wrap(function* () {
     input.write({
-      "index.js": `window.hello = "hello world";`
+      "index.js": `window.hello = "hello world";`,
+      "index.css": "body { color: green; }"
     });
 
     yield output.build();
 
     expect(output.read()).to.deep.equal({
-      "index.js": "if (typeof FastBoot === 'undefined') {\nwindow.hello = \"hello world\";\n}"
+      "index.js": "if (typeof FastBoot === 'undefined') {\nwindow.hello = \"hello world\";\n}",
+      "index.css": "body { color: green; }"
     });
   }));
 


### PR DESCRIPTION
If you have a tree with e.g. both CSS and JS in it, currently this would wrap the CSS as well, which would produce invalid output.